### PR TITLE
Update publish workflow and scripts

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -3,8 +3,6 @@ name: Build Package
 on:
   pull_request:
     branches: [master]
-  release:
-    types: [created]
 
 jobs:
   build:

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,7 +8,7 @@ import path from "path";
 import fs from "fs";
 
 const packageJson = require("./package.json");
-const minimatch = require("minimatch");
+const { minimatch } = require("minimatch");
 
 
 const Glob = require("glob");

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -1,4 +1,4 @@
-const minimatch = require("minimatch");
+const { minimatch } = require("minimatch");
 const { promisify } = require("util");
 const cp = require("child_process");
 const Glob = require("glob");


### PR DESCRIPTION
Fixed an issue with minimatch for build scripts, as well as a double build because of `build-pr.yml` running on release.